### PR TITLE
fix: configure semantic-release to publish to GitHub Packages

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -28,7 +28,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@mearman'
 
       - name: Enable Corepack
         run: corepack enable
@@ -46,8 +47,8 @@ jobs:
         id: semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN || '' }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || '' }}
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Capture the current version before release
           CURRENT_VERSION=$(node -p "require('./package.json').version")
@@ -86,21 +87,3 @@ jobs:
           subject-path: './dist'
           sbom-path: './sbom.spdx.json'
 
-      - name: Setup Node.js for GitHub Packages
-        if: steps.semantic-release.outputs.new-release-published == 'true'
-        uses: actions/setup-node@v4
-        with:
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@${{ github.repository_owner }}'
-
-      - name: Publish to GitHub Packages
-        if: steps.semantic-release.outputs.new-release-published == 'true'
-        run: |
-          # Update package name for GitHub Packages (must be lowercase)
-          npm pkg set name="@mearman/mcp-template"
-          # Ensure we're publishing to GitHub Packages registry
-          npm config set registry https://npm.pkg.github.com/
-          # Skip prepublishOnly script to avoid running tests with modified package name
-          npm publish --access public --provenance --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,8 @@
 		[
 			"@semantic-release/npm",
 			{
-				"npmPublish": true
+				"npmPublish": true,
+				"pkgRoot": "."
 			}
 		],
 		[

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
-	"name": "mcp-template",
+	"name": "@mearman/mcp-template",
 	"version": "1.1.0",
 	"description": "Template for building MCP (Model Context Protocol) servers with TypeScript",
 	"main": "dist/index.js",
 	"bin": "dist/index.js",
 	"type": "module",
+	"publishConfig": {
+		"access": "public",
+		"registry": "https://npm.pkg.github.com"
+	},
 	"scripts": {
 		"build": "tsc",
 		"dev": "tsx watch src/index.ts",
@@ -29,10 +33,6 @@
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Mearman/mcp-template.git"
-	},
-	"publishConfig": {
-		"access": "public",
-		"registry": "https://registry.npmjs.org/"
 	},
 	"files": [
 		"dist/**/*.js",


### PR DESCRIPTION
## Summary
- Fix semantic-release to publish to GitHub Packages instead of npmjs.com
- Template repositories shouldn't publish to the public npm registry

## Changes
- Updated package name to scoped `@mearman/mcp-template`
- Configured publishConfig to use GitHub Packages registry
- Updated semantic-release workflow to authenticate with GitHub Packages
- Removed duplicate publishing step (semantic-release handles it)
- Use GITHUB_TOKEN for npm authentication

## Test Plan
- [ ] CI tests pass
- [ ] Semantic release creates GitHub releases
- [ ] Package publishes to GitHub Packages (not npmjs.com)